### PR TITLE
Fix for "unbalanced parenthesis"

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -110,18 +110,19 @@ def check_declaration(content, vuln, path):
 
 
 	# Extract declaration - for ($something as $somethingelse)
-    regex_declaration2 = re.compile("\$(.*?)([\t ]*)as(?!=)([\t ]*)\$"+vuln[1:])
+    vulnerability = vuln[1:].replace(')', '\)').replace('(', '\(')
+    regex_declaration2 = re.compile("\$(.*?)([\t ]*)as(?!=)([\t ]*)\$"+vulnerability)
     declaration2       = regex_declaration2.findall(content)
     if len(declaration2) > 0:
 		return check_declaration(content, "$"+declaration2[0][0], path)
 
 	# Extract declaration - $something = $_GET['something']
-    regex_declaration = re.compile("\$"+vuln[1:]+"([\t ]*)=(?!=)(.*)")
+    regex_declaration = re.compile("\$"+vulnerability+"([\t ]*)=(?!=)(.*)")
     declaration       = regex_declaration.findall(content)
     if len(declaration)>0:
 
 		# Check constant then return True if constant because it's false positive
-		declaration_text = "$"+vuln[1:] +declaration[0][0]+"="+declaration[0][1]
+		declaration_text = "$"+vulnerability +declaration[0][0]+"="+declaration[0][1]
 		line_declaration = find_line_declaration(declaration_text, content)
 		regex_constant = re.compile("\$"+vuln[1:]+"([\t ]*)=[\t ]*?([\"\'(]*?[a-zA-Z0-9{}_\(\)@\.,!: ]*?[\"\')]*?);")
 		false_positive = regex_constant.match(declaration_text)


### PR DESCRIPTION
I was getting "sre_constants.error: unbalanced parenthesis". This small comment escapes current vulnerability to keep regular expressions happy.