### PR TITLE
Feat: add debug_print_backtrace to the list of info leak indicators

### DIFF
--- a/indicators.py
+++ b/indicators.py
@@ -145,6 +145,7 @@ payloads = [
 
     # Information Leak
     ["phpinfo", "Information Leak", []],
+    ["debug_print_backtrace", "Information Leak", []],
     ["show_source", "Information Leak", []],
     ["highlight_file", "Information Leak", []],
 


### PR DESCRIPTION
## Changes: 

- adds `debug_print_backtrace` to the list of potential information leak indicators.